### PR TITLE
fix: added reset before embeding

### DIFF
--- a/vue/src/components/PowerBICreateReport.ts
+++ b/vue/src/components/PowerBICreateReport.ts
@@ -77,7 +77,7 @@ export default defineComponent({
         console.error("HTML container is not rendered or available");
         return;
       }
-
+      this.powerbi.reset(this.$refs.containerRef as HTMLElement);
       this.embed = this.powerbi.createReport(this.$refs.containerRef as HTMLElement, this.config);
     },
 

--- a/vue/src/components/PowerBIDashboardEmbed.ts
+++ b/vue/src/components/PowerBIDashboardEmbed.ts
@@ -74,6 +74,7 @@ export default defineComponent({
      */
     embedOrBootstrap(): void {
       // Decide to embed or bootstrap
+      this.powerbi.reset(this.$refs.containerRef as HTMLElement);
       if (this.config?.accessToken && this.config?.embedUrl) {
         this.embedDashboard();
       } else {
@@ -92,7 +93,6 @@ export default defineComponent({
         console.error("HTML container is not rendered or available");
         return;
       }
-
       this.embed = this.powerbi.embed(this.$refs.containerRef as HTMLElement, this.config);
     },
 

--- a/vue/src/components/PowerBIPaginatedReportEmbed.ts
+++ b/vue/src/components/PowerBIPaginatedReportEmbed.ts
@@ -61,7 +61,7 @@ export default defineComponent({
         console.error("HTML container is not rendered or available");
         return;
       }
-
+      this.powerbi.reset(this.$refs.containerRef as HTMLElement);
       this.embed = this.powerbi.embed(this.$refs.containerRef as HTMLElement, this.config);
     },
   },

--- a/vue/src/components/PowerBIQnaEmbed.ts
+++ b/vue/src/components/PowerBIQnaEmbed.ts
@@ -73,6 +73,7 @@ export default defineComponent({
      */
     embedOrBootstrap(): void {
       // Decide to embed or bootstrap
+      this.powerbi.reset(this.$refs.containerRef as HTMLElement);
       if (this.config?.accessToken && this.config?.embedUrl) {
         this.embedQna();
       } else {

--- a/vue/src/components/PowerBIReportEmbed.ts
+++ b/vue/src/components/PowerBIReportEmbed.ts
@@ -81,6 +81,7 @@ export default defineComponent({
      */
     embedOrBootstrap(): void {
       // Decide to embed, load or bootstrap
+      this.powerbi.reset(this.$refs.containerRef as HTMLElement);
       if (this.config?.accessToken && this.config?.embedUrl) {
         this.embedReport();
       } else {

--- a/vue/src/components/PowerBITileEmbed.ts
+++ b/vue/src/components/PowerBITileEmbed.ts
@@ -74,6 +74,7 @@ export default defineComponent({
      */
     embedOrBootstrap(): void {
        // Decide to embed or bootstrap
+      this.powerbi.reset(this.$refs.containerRef as HTMLElement);
       if (this.embedConfig?.accessToken && this.embedConfig?.embedUrl) {
         this.embedTile();
       } else {

--- a/vue/src/components/PowerBIVisualEmbed.ts
+++ b/vue/src/components/PowerBIVisualEmbed.ts
@@ -73,7 +73,8 @@ export default defineComponent({
      * @returns void
      */
     embedOrBootstrap(): void {
-       if (this.config?.accessToken && this.config?.embedUrl) {
+      this.powerbi.reset(this.$refs.containerRef as HTMLElement);
+      if (this.config?.accessToken && this.config?.embedUrl) {
         this.embedVisual();
       } else {
         this.embed = this.powerbi.bootstrap(this.$refs.containerRef as HTMLElement, this.config);


### PR DESCRIPTION
Added reset before embeding, there was an issue where an already embeded/bootstrapped element could not be re-embeded, this is due to an error/limitation in the "powerbi-client" package, where the Embed class's "load" function call fails with the following error: "DOMException: Failed to execute 'postMessage' on 'Window': #<Object> could not be cloned."
The package's wiki mentions this in the limitations section, to call "reset" before changing any configuration.

Update: This is due to the fact that the iframe becomes a cross-origin frame when bootstrapped/embeded, so it cannot be modified or serialized.

https://github.com/microsoft/PowerBI-JavaScript/wiki/Bootstrap-For-Better-Performance/33507b77a8c6f028ce9e0231ae27a97fd6f4866c